### PR TITLE
Redis cache

### DIFF
--- a/.github/workflows/Iac.yml
+++ b/.github/workflows/Iac.yml
@@ -1,0 +1,35 @@
+name: Azure Bicep
+
+on:
+  workflow_dispatch
+
+env:
+  targetEnv: dev
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+    # Checkout code
+    - uses: actions/checkout@main
+
+      # Log into Azure
+    - uses: azure/login@v2.1.1
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        enable-AzPSSession: true
+
+      # Deploy ARM template
+    - name: Run ARM deploy
+      uses: azure/arm-deploy@v1
+      with:
+        subscriptionId: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        resourceGroupName: ${{ secrets.AZURE_RG }}
+        template: ./src/InfrastructureAsCode/main.bicep
+        parameters: environment=${{ env.targetEnv }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,12 +4,7 @@
 name: .NET
 
 on:
-  push:
-    branches: [ "main" ]
-    paths: src/Application/**
-  pull_request:
-    branches: [ "main" ]
-    paths: src/Application/**
+ 
     
   workflow_dispatch:
 jobs:

--- a/src/InfrastructureAsCode/main.bicep
+++ b/src/InfrastructureAsCode/main.bicep
@@ -29,6 +29,20 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-12
   }
 }
 
+resource redisCache 'Microsoft.Cache/Redis@2020-06-01' = {
+  name: 'myRedisCachefw' // Replace with your Redis cache name
+  location: resourceGroup().location
+  sku: {
+    name: 'Basic'
+    family: 'C'
+    capacity: 0
+  }
+  properties: {
+    enableNonSslPort: false
+  }
+}
+
+
 resource appInsights 'Microsoft.Insights/components@2020-02-02-preview' = {
   name: appInsightsName
   location: location


### PR DESCRIPTION
This pull request includes several changes to the GitHub Actions workflows and the infrastructure as code (IaC) setup. The most important changes include adding a new workflow for Azure Bicep deployments, modifying the .NET workflow triggers, and adding a Redis Cache resource to the Bicep template.

### GitHub Actions Workflows:

* [`.github/workflows/Iac.yml`](diffhunk://#diff-9c586536ba6c71b2bee80b8e851f170b3ff8bff87da9539285f14528e7fbceb9R1-R35): Added a new workflow for Azure Bicep deployments, including steps for checking out code, logging into Azure, and deploying an ARM template.
* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L7-R7): Modified the .NET workflow to remove push and pull request triggers on the `main` branch and paths under `src/Application`.

### Infrastructure as Code (IaC):

* [`src/InfrastructureAsCode/main.bicep`](diffhunk://#diff-a705772ad6c700e9d296ea9fb26de5e54a731a73bf57caf1f56f6bb3dbed2869R32-R45): Added a new resource definition for a Redis Cache with a basic SKU, located in the same resource group.
[Copilot is generating a summary...]