### PR TITLE
Add Redis Cache resource to Bicep template

### DIFF
--- a/src/InfrastructureAsCode/main.bicep
+++ b/src/InfrastructureAsCode/main.bicep
@@ -13,7 +13,25 @@ var registryName = '${uniqueString(resourceGroup().id)}mpnpreg'
 var registrySku = 'Standard'
 var imageName = 'techexcel/dotnetcoreapp'
 var startupCommand = ''
+var redisCacheName = '${uniqueString(resourceGroup().id)}-mpnp-redis'
+var redisCacheSku = 'Basic'
 
+resource redisCache 'Microsoft.Cache/Redis@2023-08-01' = {
+  name: redisCacheName
+  location: location
+  properties: {
+    sku: {
+      name: redisCacheSku
+      family: 'C'
+      capacity: 0
+    }
+    enableNonSslPort: false
+    minimumTlsVersion: '1.2'
+    redisConfiguration: {
+      'maxmemory-policy': 'volatile-lru'
+    }
+  }
+}
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-12-01-preview' = {
   name: logAnalyticsName
@@ -29,18 +47,6 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-12
   }
 }
 
-resource redisCache 'Microsoft.Cache/Redis@2020-06-01' = {
-  name: 'myRedisCachefw' // Replace with your Redis cache name
-  location: resourceGroup().location
-  sku: {
-    name: 'Basic'
-    family: 'C'
-    capacity: 0
-  }
-  properties: {
-    enableNonSslPort: false
-  }
-}
 
 
 resource appInsights 'Microsoft.Insights/components@2020-02-02-preview' = {


### PR DESCRIPTION
This pull request includes updates to the `src/InfrastructureAsCode/main.bicep` file to enhance the configuration of the Redis Cache resource. The most important changes involve updating the Redis Cache resource definition and adding new properties to improve its configuration.

Redis Cache configuration updates:

* Added new variables `redisCacheName` and `redisCacheSku` for naming and SKU configuration of the Redis Cache. (`src/InfrastructureAsCode/main.bicep`)
* Updated the Redis Cache resource definition to use the latest API version `2023-08-01` and added new properties such as `minimumTlsVersion` and `redisConfiguration`. (`src/InfrastructureAsCode/main.bicep`)
* Removed the old Redis Cache resource definition that used an older API version `2020-06-01` and had fewer configuration options. (`src/InfrastructureAsCode/main.bicep`)